### PR TITLE
Fix for reading hierarchy of entities from xml when id property is in su...

### DIFF
--- a/impl/src/main/java/com/ctp/cdi/query/meta/unit/EntityDescriptor.java
+++ b/impl/src/main/java/com/ctp/cdi/query/meta/unit/EntityDescriptor.java
@@ -7,7 +7,7 @@ import java.io.Serializable;
 
 class EntityDescriptor extends PersistentClassDescriptor {
     
-    private MappedSuperclassDescriptor superClass;
+    
 
     EntityDescriptor(String name, String packageName, String className, String idClass, String id) {
         super(name, packageName, className, idClass, id);
@@ -19,30 +19,18 @@ class EntityDescriptor extends PersistentClassDescriptor {
     
     @Override
     public Class<? extends Serializable> getIdClass() {
-        if (idClass == null && superClass != null) {
-            return superClass.getIdClass();
+        if (idClass == null && getParent() != null) {
+            return getParent().getIdClass();
         }
         return super.getIdClass();
     }
 
     @Override
     public String getId() {
-        if (isEmpty(id) && superClass != null) {
-            return superClass.getId();
+        if (isEmpty(id) && getParent() != null) {
+            return getParent().getId();
         }
         return super.getId();
-    }
-
-    public boolean assignSuperclassIfMatching(MappedSuperclassDescriptor superClass) {
-        MappedSuperclassDescriptor current = superClass;
-        while (current != null) {
-            if (current.getEntityClass().isAssignableFrom(entityClass)) {
-                this.superClass = current;
-                return true;
-            }
-            current = current.getParent();
-        }
-        return false;
     }
 
     @Override
@@ -53,17 +41,11 @@ class EntityDescriptor extends PersistentClassDescriptor {
                 .append(", name=").append(name)
                 .append(", idClass=").append(className(idClass))
                 .append(", id=").append(id)
-                .append(", superClass=").append(superClass)
+                .append(", superClass=").append(getParent())
                 .append("]");
         return builder.toString();
     }
 
-    public MappedSuperclassDescriptor getSuperClass() {
-        return superClass;
-    }
 
-    public void setSuperClass(MappedSuperclassDescriptor superClass) {
-        this.superClass = superClass;
-    }
     
 }

--- a/impl/src/main/java/com/ctp/cdi/query/meta/unit/MappedSuperclassDescriptor.java
+++ b/impl/src/main/java/com/ctp/cdi/query/meta/unit/MappedSuperclassDescriptor.java
@@ -7,37 +7,25 @@ import java.io.Serializable;
 
 class MappedSuperclassDescriptor extends PersistentClassDescriptor {
     
-    private MappedSuperclassDescriptor parent;
+    
 
     MappedSuperclassDescriptor(String name, String packageName, String className, String idClass, String id) {
         super(name, packageName, className, idClass, id);
     }
 
-    public void insert(MappedSuperclassDescriptor descriptor) {
-        if (parent != null) {
-            if (parent.getEntityClass().isAssignableFrom(descriptor.getEntityClass())) {
-                descriptor.insert(parent);
-                parent = descriptor;
-            } else {
-                parent.insert(descriptor);
-            }
-        } else {
-            parent = descriptor;
-        }
-    }
     
     @Override
     public Class<? extends Serializable> getIdClass() {
-        if (idClass == null && parent != null) {
-            return parent.getIdClass();
+        if (idClass == null && getParent() != null) {
+            return getParent().getIdClass();
         }
         return super.getIdClass();
     }
 
     @Override
     public String getId() {
-        if (isEmpty(id) && parent != null) {
-            return parent.getId();
+        if (isEmpty(id) && getParent() != null) {
+            return getParent().getId();
         }
         return super.getId();
     }
@@ -50,13 +38,11 @@ class MappedSuperclassDescriptor extends PersistentClassDescriptor {
                 .append(", name=").append(name)
                 .append(", idClass=").append(className(idClass))
                 .append(", id=").append(id)
-                .append(", parent=").append(parent)
+                .append(", parent=").append(getParent())
                 .append("]");
         return builder.toString();
     }
 
-    public MappedSuperclassDescriptor getParent() {
-        return parent;
-    }
+
 
 }

--- a/impl/src/main/java/com/ctp/cdi/query/meta/unit/PersistentClassDescriptor.java
+++ b/impl/src/main/java/com/ctp/cdi/query/meta/unit/PersistentClassDescriptor.java
@@ -12,6 +12,7 @@ abstract class PersistentClassDescriptor {
     final Class<?> entityClass;
     final Class<? extends Serializable> idClass;
     final String id;
+    private PersistentClassDescriptor parent;
 
     PersistentClassDescriptor(String name, String packageName, String className, String idClass, String id) {
         Class<?> clazz = entityClass(className, packageName);
@@ -79,4 +80,14 @@ abstract class PersistentClassDescriptor {
     private boolean isClassNameQualified(String name) {
         return name.contains(".");
     }
+
+    public PersistentClassDescriptor getParent() {
+        return parent;
+    }
+
+    public void setParent(PersistentClassDescriptor parent) {
+        this.parent = parent;
+    }
+
+
 }

--- a/impl/src/test/java/com/ctp/cdi/query/meta/unit/DescriptorHierarchyBuilderTest.java
+++ b/impl/src/test/java/com/ctp/cdi/query/meta/unit/DescriptorHierarchyBuilderTest.java
@@ -37,12 +37,12 @@ public class DescriptorHierarchyBuilderTest {
         assertEquals(entities.size(), 2);
         assertEquals(EntityLevel3.class, entities.get(0).getEntityClass());
         assertEquals(EntityLevel5.class, entities.get(1).getEntityClass());
-        assertEquals(MappedLevel2.class, entities.get(0).getSuperClass().getEntityClass());
-        assertEquals(MappedLevel4.class, entities.get(1).getSuperClass().getEntityClass());
+        assertEquals(MappedLevel2.class, entities.get(0).getParent().getEntityClass());
+        assertEquals(MappedLevel4.class, entities.get(1).getParent().getEntityClass());
         
         assertEquals(superClasses.size(), 4);
         assertNull(superClasses.get(0).getParent());
-        assertEquals(MappedLevel2.class, superClasses.get(1).getParent().getEntityClass());
+        assertEquals(EntityLevel3.class, superClasses.get(1).getParent().getEntityClass());
         assertNull(superClasses.get(2).getParent());
         assertEquals(MappedLevel1.class, superClasses.get(3).getParent().getEntityClass());
     }


### PR DESCRIPTION
This fix situation when id property is in common entity not in mapped super type. I've slightly changed the way in which hierarchy is build. For each entity found in xml, I search path of superclasses for either entity or mappedsupertype.
