### PR TITLE
support for query hint configuration with @Query annotation

### DIFF
--- a/api/src/main/java/com/ctp/cdi/query/Query.java
+++ b/api/src/main/java/com/ctp/cdi/query/Query.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.persistence.LockModeType;
+import javax.persistence.*;
 
 /**
  * Supply query meta data to a method with this annotation.<br/>
@@ -46,5 +46,10 @@ public @interface Query {
      * Defines a lock mode for the query.
      */
     LockModeType lock() default LockModeType.NONE;
-    
+
+    /** (Optional) Query properties and hints.  May include
+     * vendor-specific query hints.
+     */
+    QueryHint[] hints() default {};
+
 }


### PR DESCRIPTION
I'd like to configure caching hints using the @Query annotation, so I added the hints attribute and modified QueryBuilder. I think that's enough to make it work and tested it with a small project of mine. Didn't write any unit tests though.
